### PR TITLE
define new cell array ind2depo

### DIFF
--- a/gp/gpla_e.m
+++ b/gp/gpla_e.m
@@ -2126,7 +2126,7 @@ function [e, g, h] = egh(f, varargin)
   h = -gp.lik.fh.llg2(gp.lik, y, f', 'latent', z);
 end
 function ikf = iKf(f, varargin)
-  
+  ind2depo = {}
   switch gp.type
     case {'PIC' 'PIC_BLOCK'}
       iLaf = zeros(size(f));


### PR DESCRIPTION
this pr replaces previous one, which contained bbd54d0.  cell array ind2depo may already be in the environment as a Mathworks toolkit function, so re-initialize it inside gpla_e to avoid an error